### PR TITLE
Added cage climb logic

### DIFF
--- a/Custom Arena Readme.txt
+++ b/Custom Arena Readme.txt
@@ -9,6 +9,7 @@ This readme is if you want to use unity to create a custom arena and has some gu
 
 -Make barriers that can be climbed on like the original arena barriers that can be climbed on / over. Simply make sure your barriers start with the name "Barrier_Climbables" (If you put them as a child of an object to group them, don't have "Barrier_Climbables" in the parents name) The mod will then render a climbable collision box around these objects for you as long as they have an appropriate meshCollider set.
 
+-Also can make "Cage" like climbable terrain, eg for chainlink fences. Just name it "Fence_Climbables" and the rest of the logic will work like the barriers but with cage climbing logic.
 
 -Set custom camera distance, make an object called camDistance200, will set the camera distance to 200 (Default arena camera distance is 135 which this mod will set it to if you don't make this object.) If you are wondering why you want this, I found this setting impacts when the name tag will appear and fireworks / smoke etc from entrances happens, the lower the camera distance, the closer to the ring the entrance effect seems to trigger. Also is just useful if you want to make small indoor maps like new backstage rooms.
 

--- a/Patches/WorldPatch.cs
+++ b/Patches/WorldPatch.cs
@@ -241,7 +241,6 @@ public class WorldPatch
                 GameCollision.DKPMHGHNHEH[peifijckaoc].EDHBIOFAKNL = worldCorners[0].y;
                 GameCollision.DKPMHGHNHEH[peifijckaoc].HHMMCHPDDPF = worldCorners[1].y;
                 GameCollision.DKPMHGHNHEH[peifijckaoc].DIDCENDAHFF = 1;
-                //Below controls the type of collision, tempted to replicate this foreach loop for other object names for other collision types like "Cage"
                 GameCollision.DKPMHGHNHEH[peifijckaoc].BGJDFONPLFK = "Barrier";
                 GameCollision.DKPMHGHNHEH[peifijckaoc].MIFAPPFHEPA[1] = worldCorners[4].x + 2.5f;
                 GameCollision.DKPMHGHNHEH[peifijckaoc].NGLDIFNHFED[1] = worldCorners[4].z + 2.5f;
@@ -252,6 +251,54 @@ public class WorldPatch
                 GameCollision.DKPMHGHNHEH[peifijckaoc].MIFAPPFHEPA[2] = worldCorners[0].x + 2.5f;
                 GameCollision.DKPMHGHNHEH[peifijckaoc].NGLDIFNHFED[2] = worldCorners[0].z - 2.5f;
             }
+
+            foreach (GameObject gameObject in (from t in World.gArena.GetComponentsInChildren<Transform>()
+                                               where t.gameObject != null && t.gameObject.name.StartsWith("Fence_Climbables")
+                                               select t.gameObject).ToArray<GameObject>())
+            {
+                MeshCollider meshCollider = gameObject.GetComponent<MeshCollider>();
+
+                Bounds bounds = meshCollider.sharedMesh.bounds;
+
+                Vector3 center = bounds.center;
+                Vector3 extents = bounds.extents;
+
+                // Calculate the 8 corners of the bounding box
+                Vector3[] corners = new Vector3[8];
+                corners[0] = center + new Vector3(-extents.x, -extents.y, -extents.z);
+                corners[1] = center + new Vector3(-extents.x, -extents.y, extents.z);
+                corners[2] = center + new Vector3(extents.x, -extents.y, extents.z);
+                corners[3] = center + new Vector3(extents.x, -extents.y, -extents.z);
+                corners[4] = center + new Vector3(-extents.x, extents.y, -extents.z);
+                corners[5] = center + new Vector3(-extents.x, extents.y, extents.z);
+                corners[6] = center + new Vector3(extents.x, extents.y, extents.z);
+                corners[7] = center + new Vector3(extents.x, extents.y, -extents.z);
+
+                // Get the 8 corners of the bounding box as world position
+                Vector3[] worldCorners = new Vector3[corners.Length];
+                for (int i = 0; i < corners.Length; i++)
+                {
+                    worldCorners[i] = meshCollider.transform.TransformPoint(corners[i]);
+                }
+
+                GameCollision.BELIFAOEFAK++;
+                int peifijckaoc = GameCollision.BELIFAOEFAK;
+                GameCollision.LKMAEOFENHG();
+                GameCollision.DKPMHGHNHEH[peifijckaoc].EPGJJDJAACP = 0f;
+                GameCollision.DKPMHGHNHEH[peifijckaoc].EDHBIOFAKNL = worldCorners[0].y;
+                GameCollision.DKPMHGHNHEH[peifijckaoc].HHMMCHPDDPF = worldCorners[1].y;
+                GameCollision.DKPMHGHNHEH[peifijckaoc].DIDCENDAHFF = 1;
+                GameCollision.DKPMHGHNHEH[peifijckaoc].BGJDFONPLFK = "Cage";
+                GameCollision.DKPMHGHNHEH[peifijckaoc].MIFAPPFHEPA[1] = worldCorners[4].x + 2.5f;
+                GameCollision.DKPMHGHNHEH[peifijckaoc].NGLDIFNHFED[1] = worldCorners[4].z + 2.5f;
+                GameCollision.DKPMHGHNHEH[peifijckaoc].MIFAPPFHEPA[4] = worldCorners[7].x - 2.5f;
+                GameCollision.DKPMHGHNHEH[peifijckaoc].NGLDIFNHFED[4] = worldCorners[7].z + 2.5f;
+                GameCollision.DKPMHGHNHEH[peifijckaoc].MIFAPPFHEPA[3] = worldCorners[3].x - 2.5f;
+                GameCollision.DKPMHGHNHEH[peifijckaoc].NGLDIFNHFED[3] = worldCorners[3].z - 2.5f;
+                GameCollision.DKPMHGHNHEH[peifijckaoc].MIFAPPFHEPA[2] = worldCorners[0].x + 2.5f;
+                GameCollision.DKPMHGHNHEH[peifijckaoc].NGLDIFNHFED[2] = worldCorners[0].z - 2.5f;
+            }
+
             for (GameCollision.BELIFAOEFAK = last + 1; GameCollision.BELIFAOEFAK <= GameCollision.DGPJFOABPND; GameCollision.BELIFAOEFAK++)
             {
                 if (GameCollision.DKPMHGHNHEH[GameCollision.BELIFAOEFAK].HFNGNNHNFIC != null)


### PR DESCRIPTION
Adds ability for cage climb logic by using name "Fence_Climbables" and works same way barriers do but using the cage logic. Custom Arena Readme updated for this as well.