### PR TITLE
Added ability to stop announcers moving

### DIFF
--- a/Custom Arena Readme.txt
+++ b/Custom Arena Readme.txt
@@ -38,5 +38,6 @@ Belt, Microphone, Camera, Bell, Explosive, Baseball Bat, Chair, Cage Piece, Wood
 
 In addition, you can use "WeaponObject:Random", "WeaponObject:Random2" etc to spawn a random weapon at a fixed location (This will also sometimes spawn nothing if it randomly hits a weapon that doesn't work)
 
+-If you have announce desk further from ring and find your announcers leave their seats to go stand at ringside, simply make an object called "AnnouncerFreeze" and the mod will disable the announcer AI so they don't leave their chairs.
 
 Any questions try the modding discord here: https://discord.gg/mH56AhUwPR

--- a/Patches/ArenaPatch.cs
+++ b/Patches/ArenaPatch.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Text.RegularExpressions;
 using WECCL.Content;
 using Debug = UnityEngine.Debug;
@@ -285,7 +284,44 @@ public class ArenaPatch
                 }
             }
         }
-        
+
+        [HarmonyPatch(typeof(GMIKIMHFABP))]
+        public static class GMIKIMHFABPPatch
+        {
+            public static int storedValue;
+            [HarmonyPrefix]
+            [HarmonyPatch("GCGDPDLEHPH")]
+            public static void GCGDPDLEHPHPatch(GMIKIMHFABP __instance)
+            {
+                GameObject[] objects = GameObject.FindObjectsOfType<GameObject>();
+                GameObject[] announcerFreezeObj = objects.Where(obj => obj.name.StartsWith("AnnouncerFreeze")).ToArray();
+                if (announcerFreezeObj != null)
+                {
+                    if (__instance.MMDNKLMAOEF == 0)
+                    {
+                        storedValue = __instance.KEBLMJDJIFJ;
+                        __instance.KEBLMJDJIFJ = 0;
+                    }
+                }
+            }
+            [HarmonyPostfix]
+            [HarmonyPatch("GCGDPDLEHPH")]
+            public static void GCGDPDLEHPHPostPatch(GMIKIMHFABP __instance)
+            {
+                GameObject[] objects = GameObject.FindObjectsOfType<GameObject>();
+                GameObject[] announcerFreezeObj = objects.Where(obj => obj.name.StartsWith("AnnouncerFreeze")).ToArray();
+                if (announcerFreezeObj != null)
+                {
+                    if (__instance.MMDNKLMAOEF == 0)
+                    {
+                        if (storedValue != __instance.KEBLMJDJIFJ)
+                        {
+                            __instance.KEBLMJDJIFJ = storedValue;
+                        }
+                    }
+                }
+            }
+        }
 
         [HarmonyPostfix]
         [HarmonyPatch("PKHEPCDDIBM")]
@@ -562,7 +598,7 @@ public class ArenaPatch
                     num = ELMNDAABAFD;
                 }
             }
-            //Reset customY to 0 before leaving
+            
             __result = num;
 
             void CustomGameObjectSpawner(GameObject customObject)
@@ -665,6 +701,9 @@ public class ArenaPatch
                 __instance.GOGMLEFHKHE = yOverride;
                 __instance.PBFJIDAPJGL = yOverride;
                 __instance.EDHBIOFAKNL = yOverride;
+
+                //Set yOverride back to 0 afterwards so going to another map doesn't spawn all furniture in the air...
+                yOverride = 0f;
             }
         }
     }


### PR DESCRIPTION
If you have announce desk further from ring and find your announcers leave their seats to go stand at ringside, simply make an object called "AnnouncerFreeze" and the mod will disable the announcer AI so they don't leave their chairs.

Also fixed Y override so it can't make furniture on normal maps spawn in air if were previously on a custom map.