### PR TITLE
Fixed FindAndProcessCrowdObjects to work on any custom arena

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   warned.
 - P.S. Ingo is very nice and would never do such a thing. But still, back up your save file. Or else...
 
-- ### Release 1.6.1
+### Release 1.6.1
 - Broken save files will now be attempted to be repaired on launch.
 - Added support for mentioning moves in custom promos.
 - Added support for additional crowd and signs in custom arenas.

--- a/Patches/ArenaPatch.cs
+++ b/Patches/ArenaPatch.cs
@@ -477,9 +477,13 @@ public class ArenaPatch
             if (World.location > VanillaCounts.Data.NoLocations)
             {
                 //Replaces crowd textures while keeping materials, shaders etc
-                Transform parentTransform = World.gArena.transform.Find("arena");
+                Transform parentTransform = World.gArena.transform.root;
 
-                FindAndProcessCrowdObjects(parentTransform);
+                //Shouldn't ever be null here but adding check anyway
+                if (parentTransform != null)
+                {
+                    FindAndProcessCrowdObjects(parentTransform);
+                }
             }
 
             for (int i = 1; i <= num2; i++)

--- a/Patches/ArenaPatch.cs
+++ b/Patches/ArenaPatch.cs
@@ -705,7 +705,7 @@ public class ArenaPatch
                     }
                 }
 
-                if (CrowdCount > 10)
+                if (CrowdCount >= 10)
                 {
                     CrowdCount += 1;
                     //Don't need to do any of this if CrowdCount hasn't changed, otherwise make sure virtual crowd is the last value

--- a/Patches/ArenaPatch.cs
+++ b/Patches/ArenaPatch.cs
@@ -1680,7 +1680,12 @@ public class ArenaPatch
             {
                 if ((IKBHGAKKJMM == 28 || IKBHGAKKJMM == 31) && __instance.OEGJEBDBGJA.shape[IKBHGAKKJMM] > 0)
                 {
-                    Transform ReferenceObject = World.gArena.transform.Find("SolidShader");
+                    Transform ReferenceObject = null;
+                    if (World.gArena != null)
+                    {
+                        ReferenceObject = World.gArena.transform.Find("SolidShader");
+                    }
+
 
                     if (ReferenceObject != null)
                     {


### PR DESCRIPTION
Fixed FindAndProcessCrowdObjects to work on any custom arena and not just ones that use the custom arena template. Seems to be only place I forgot to make sure would work for all custom arenas.