### PR TITLE
Experimental custom match support

### DIFF
--- a/Content/CustomMatch.cs
+++ b/Content/CustomMatch.cs
@@ -5,29 +5,43 @@ public class CustomMatch
     internal static Dictionary<string, int> CustomPresetsNeg = new();
     internal static Dictionary<string, int> CustomCagesPos = new();
     internal static Dictionary<string, int> CustomCagesNeg = new();
+
+    /// <summary>
+    /// <para>Use this to register your custom match preset and get a preset ID.</para>
+    /// <para>string Name - name identifier.</para>
+    /// <para>bool PositiveValue - "true" to add to the positive end of the list, "false" to add to the negative end instead.</para>
+    /// </summary>
+    /// <param name="Name">Name identifier</param>
+    /// <param name="PositiveValue">"true" to add to the positive end of the list, "false" to add to the negative end instead.</param>
+    /// <returns>The ID of your custom preset, null if it fails.</returns>
     public static int? RegisterCustomPreset(string Name, bool PositiveValue)
     {
         int value;
         if (PositiveValue)
         {
-            if (Register(Name, CustomPresetsPos, "Preset", out value))
+            if (CustomPresetsPos.TryGetValue(Name, out value))
             {
-                Plugin.Log.LogInfo("REGISTERED " + Name + " " + -value);
+                Plugin.Log.LogWarning(Name + " is already registered as preset " + value);
+            }
+            else
+            {
+                value = ++MappedMatch.no_presets;
+                Plugin.Log.LogInfo("REGISTERED " + Name + " as preset " + value);
                 CustomPresetsPos.Add(Name, value);
             }
             return value;
         }
         else
         {
-            if (Register(Name, CustomPresetsNeg, "Preset", out value))
+            if (RegisterHardcodedElement(Name, CustomPresetsNeg, "Preset", out value))
             {
-                Plugin.Log.LogInfo("REGISTERED " + Name + " " + -value);
+                Plugin.Log.LogInfo("REGISTERED " + Name + " as preset " + -value);
                 CustomPresetsNeg.Add(Name, -value);
             }
             return -value;
         }
     }
-    private static bool Register(string Name, Dictionary<string, int> dictionary, string type, out int pos)
+    private static bool RegisterHardcodedElement(string Name, Dictionary<string, int> dictionary, string type, out int pos)
     {
         if (dictionary.TryGetValue(Name, out pos))
         {
@@ -37,23 +51,31 @@ public class CustomMatch
         pos = 10001 + dictionary.Count;
         return true;
     }
+    /// <summary>
+    /// <para>Use this to register your custom cage and get a cage ID.</para>
+    /// <para>string Name - name identifier.</para>
+    /// <para>bool PositiveValue - "true" to add to the positive end of the list, "false" to add to the negative end instead.</para>
+    /// </summary>
+    /// <param name="Name">Name identifier</param>
+    /// <param name="PositiveValue">"true" to add to the positive end of the list, "false" to add to the negative end instead.</param>
+    /// <returns>The ID of your custom cage, null if it fails.</returns>
     public static int? RegisterCustomCage(string Name, bool PositiveValue)
     {
         int value;
         if (PositiveValue)
         {
-            if (Register(Name, CustomCagesPos, "Cage", out value))
+            if (RegisterHardcodedElement(Name, CustomCagesPos, "Cage", out value))
             {
-                Plugin.Log.LogInfo("REGISTERED " + Name + " " + value);
+                Plugin.Log.LogInfo("REGISTERED " + Name + " as cage " + value);
                 CustomCagesPos.Add(Name, value);
             }
             return value;
         }
         else
         {
-            if (Register(Name, CustomCagesNeg, "Cage", out value))
+            if (RegisterHardcodedElement(Name, CustomCagesNeg, "Cage", out value))
             {
-                Plugin.Log.LogInfo("REGISTERED " + Name + " " + -value);
+                Plugin.Log.LogInfo("REGISTERED " + Name + " as cage " + -value);
                 CustomCagesNeg.Add(Name, -value);
             }
             return -value;

--- a/Content/CustomMatch.cs
+++ b/Content/CustomMatch.cs
@@ -1,0 +1,62 @@
+﻿namespace WECCL.Content;
+public class CustomMatch
+{
+    internal static Dictionary<string, int> CustomPresetsPos = new();
+    internal static Dictionary<string, int> CustomPresetsNeg = new();
+    internal static Dictionary<string, int> CustomCagesPos = new();
+    internal static Dictionary<string, int> CustomCagesNeg = new();
+    public static int? RegisterCustomPreset(string Name, bool PositiveValue)
+    {
+        int value;
+        if (PositiveValue)
+        {
+            if (Register(Name, CustomPresetsPos, "Preset", out value))
+            {
+                Plugin.Log.LogInfo("REGISTERED " + Name + " " + -value);
+                CustomPresetsPos.Add(Name, value);
+            }
+            return value;
+        }
+        else
+        {
+            if (Register(Name, CustomPresetsNeg, "Preset", out value))
+            {
+                Plugin.Log.LogInfo("REGISTERED " + Name + " " + -value);
+                CustomPresetsPos.Add(Name, -value);
+            }
+            return value;
+        }
+    }
+    private static bool Register(string Name, Dictionary<string, int> dictionary, string type, out int pos)
+    {
+        if (dictionary.TryGetValue(Name, out pos))
+        {
+            Plugin.Log.LogWarning(Name + " is already registered as " + type + " " + pos);
+            return false;
+        }
+        pos = 10001 + dictionary.Count;
+        return true;
+    }
+    public static int? RegisterCustomCage(string Name, bool PositiveValue)
+    {
+        int value;
+        if (PositiveValue)
+        {
+            if (Register(Name, CustomCagesPos, "Cage", out value))
+            {
+                Plugin.Log.LogInfo("REGISTERED " + Name + " " + value);
+                CustomPresetsPos.Add(Name, value);
+            }
+            return value;
+        }
+        else
+        {
+            if (Register(Name, CustomCagesNeg, "Cage", out value))
+            {
+                Plugin.Log.LogInfo("REGISTERED " + Name + " " + -value);
+                CustomPresetsPos.Add(Name, -value);
+            }
+            return value;
+        }
+    }
+}

--- a/Content/CustomMatch.cs
+++ b/Content/CustomMatch.cs
@@ -22,9 +22,9 @@ public class CustomMatch
             if (Register(Name, CustomPresetsNeg, "Preset", out value))
             {
                 Plugin.Log.LogInfo("REGISTERED " + Name + " " + -value);
-                CustomPresetsPos.Add(Name, -value);
+                CustomPresetsNeg.Add(Name, -value);
             }
-            return value;
+            return -value;
         }
     }
     private static bool Register(string Name, Dictionary<string, int> dictionary, string type, out int pos)
@@ -45,7 +45,7 @@ public class CustomMatch
             if (Register(Name, CustomCagesPos, "Cage", out value))
             {
                 Plugin.Log.LogInfo("REGISTERED " + Name + " " + value);
-                CustomPresetsPos.Add(Name, value);
+                CustomCagesPos.Add(Name, value);
             }
             return value;
         }
@@ -54,9 +54,9 @@ public class CustomMatch
             if (Register(Name, CustomCagesNeg, "Cage", out value))
             {
                 Plugin.Log.LogInfo("REGISTERED " + Name + " " + -value);
-                CustomPresetsPos.Add(Name, -value);
+                CustomCagesNeg.Add(Name, -value);
             }
-            return value;
+            return -value;
         }
     }
 }

--- a/Patches/MatchTypePatch.cs
+++ b/Patches/MatchTypePatch.cs
@@ -5,7 +5,6 @@ namespace WECCL.Patches;
 [HarmonyPatch]
 public class MatchTypePatch
 {
-    private static float OldPresetMax;
     private static float OldPresetMin;
     private static float OldCageMax;
     private static float OldCageMin;
@@ -19,20 +18,12 @@ public class MatchTypePatch
         {
             if (LIPNHOMGGHF.FKANHDIMMBJ[1] == __instance)
             {
-                OldPresetMax = LKBOHHGFJFO;
                 OldPresetMin = JBPAELFIDOP;
                 JBPAELFIDOP -= CustomMatch.CustomPresetsNeg.Count;
-                LKBOHHGFJFO += CustomMatch.CustomPresetsPos.Count;
-               // Debug.LogWarning("OLD " + CAAJBNHEFJJ);
-                if (CAAJBNHEFJJ >= 10000)
-                {
-                    CAAJBNHEFJJ = CAAJBNHEFJJ - 10000 + OldPresetMax;
-                }
                 if (CAAJBNHEFJJ <= -10000)
                 {
                     CAAJBNHEFJJ = CAAJBNHEFJJ + 10000 - OldPresetMin;
                 }
-               // Debug.LogWarning("NEW " + CAAJBNHEFJJ);
             }
         }    
     }
@@ -45,13 +36,7 @@ public class MatchTypePatch
         {
             if (LIPNHOMGGHF.FKANHDIMMBJ[1] == __instance)
             {
-               // Debug.LogWarning("OLD R " + __result);
-                if (__result > OldPresetMax)
-                {
-                    __result = 10000 + (__result - OldPresetMax);
-                }
                 if (__result < OldPresetMin) __result = -10000 - (OldPresetMin - __result);
-              //  Debug.LogWarning("NEW R " + __result);
             }
         }
     }
@@ -64,18 +49,7 @@ public class MatchTypePatch
         {
             if (LIPNHOMGGHF.FKANHDIMMBJ[9] == __instance)
             {
-                OldCageMax = LKBOHHGFJFO;
-                OldCageMin = JBPAELFIDOP;
-                JBPAELFIDOP -= CustomMatch.CustomCagesNeg.Count;
-                LKBOHHGFJFO += CustomMatch.CustomCagesPos.Count;
-                if (CAAJBNHEFJJ >= 10000)
-                {
-                    CAAJBNHEFJJ = CAAJBNHEFJJ - 10000 + OldCageMax;
-                }
-                if (CAAJBNHEFJJ <= -10000)
-                {
-                    CAAJBNHEFJJ = CAAJBNHEFJJ + 10000 - OldCageMin;
-                }
+                ChangeHardcodedPrefix(ref OldCageMin, ref JBPAELFIDOP, CustomMatch.CustomCagesNeg.Count, ref OldCageMax, ref LKBOHHGFJFO, CustomMatch.CustomCagesPos.Count, ref CAAJBNHEFJJ);
             }
         }
     }
@@ -88,12 +62,31 @@ public class MatchTypePatch
         {
             if (LIPNHOMGGHF.FKANHDIMMBJ[9] == __instance)
             {
-                if (__result > OldCageMax)
-                {
-                    __result = 10000 + (__result - OldCageMax);
-                }
-                if (__result < OldCageMin) __result = -10000 - (OldCageMin - __result);
+                ChangeHardcodedPostfix(ref __result, OldCageMin, OldCageMax);
             }
         }
+    }
+    private static void ChangeHardcodedPrefix(ref float OldMin, ref float GameMin, int NegativesCount, ref float OldMax, ref float GameMax, int PositivesCount, ref float CurrentValue)
+    {
+        OldMax = GameMax;
+        OldMin = GameMin;
+        GameMin -= NegativesCount;
+        GameMax += PositivesCount;
+        if (CurrentValue >= 10000)
+        {
+            CurrentValue = CurrentValue - 10000 + OldMax;
+        }
+        if (CurrentValue <= -10000)
+        {
+            CurrentValue = CurrentValue + 10000 - OldMin;
+        }
+    }
+    private static void ChangeHardcodedPostfix(ref float __result, float OldMin, float OldMax)
+    {
+        if (__result > OldMax)
+        {
+            __result = 10000 + (__result - OldMax);
+        }
+        if (__result < OldMin) __result = -10000 - (OldMin - __result);
     }
 }

--- a/Patches/MatchTypePatch.cs
+++ b/Patches/MatchTypePatch.cs
@@ -23,6 +23,7 @@ public class MatchTypePatch
                 OldPresetMin = JBPAELFIDOP;
                 JBPAELFIDOP -= CustomMatch.CustomPresetsNeg.Count;
                 LKBOHHGFJFO += CustomMatch.CustomPresetsPos.Count;
+               // Debug.LogWarning("OLD " + CAAJBNHEFJJ);
                 if (CAAJBNHEFJJ >= 10000)
                 {
                     CAAJBNHEFJJ = CAAJBNHEFJJ - 10000 + OldPresetMax;
@@ -31,6 +32,7 @@ public class MatchTypePatch
                 {
                     CAAJBNHEFJJ = CAAJBNHEFJJ + 10000 - OldPresetMin;
                 }
+               // Debug.LogWarning("NEW " + CAAJBNHEFJJ);
             }
         }    
     }
@@ -43,11 +45,13 @@ public class MatchTypePatch
         {
             if (LIPNHOMGGHF.FKANHDIMMBJ[1] == __instance)
             {
+               // Debug.LogWarning("OLD R " + __result);
                 if (__result > OldPresetMax)
                 {
                     __result = 10000 + (__result - OldPresetMax);
                 }
                 if (__result < OldPresetMin) __result = -10000 - (OldPresetMin - __result);
+              //  Debug.LogWarning("NEW R " + __result);
             }
         }
     }

--- a/Patches/MatchTypePatch.cs
+++ b/Patches/MatchTypePatch.cs
@@ -1,0 +1,95 @@
+﻿using UnityEngine.SceneManagement;
+using WECCL.Content;
+namespace WECCL.Patches;
+
+[HarmonyPatch]
+public class MatchTypePatch
+{
+    private static float OldPresetMax;
+    private static float OldPresetMin;
+    private static float OldCageMax;
+    private static float OldCageMin;
+   
+    [HarmonyPatch(typeof(UnmappedMenu), nameof(UnmappedMenu.ODONMLDCHHF))]
+    [HarmonyPrefix]
+    private static void CustomPresetPrefix(UnmappedMenu __instance, float __result, ref float CAAJBNHEFJJ, float OEGLNPMNEOE, float NOGFHHECJBM, ref float JBPAELFIDOP, ref float LKBOHHGFJFO, int LKJHMOHMKCM)
+    {
+        if (SceneManager.GetActiveScene().name != "Match_Setup") return;
+        if (LIPNHOMGGHF.CHLJMEPFJOK == 2)
+        {
+            if (LIPNHOMGGHF.FKANHDIMMBJ[1] == __instance)
+            {
+                OldPresetMax = LKBOHHGFJFO;
+                OldPresetMin = JBPAELFIDOP;
+                JBPAELFIDOP -= CustomMatch.CustomPresetsNeg.Count;
+                LKBOHHGFJFO += CustomMatch.CustomPresetsPos.Count;
+                if (CAAJBNHEFJJ >= 10000)
+                {
+                    CAAJBNHEFJJ = CAAJBNHEFJJ - 10000 + OldPresetMax;
+                }
+                if (CAAJBNHEFJJ <= -10000)
+                {
+                    CAAJBNHEFJJ = CAAJBNHEFJJ + 10000 - OldPresetMin;
+                }
+            }
+        }    
+    }
+    [HarmonyPatch(typeof(UnmappedMenu), nameof(UnmappedMenu.ODONMLDCHHF))]
+    [HarmonyPostfix]
+    private static void CustomPresetPostfix(UnmappedMenu __instance, ref float __result, float CAAJBNHEFJJ, float OEGLNPMNEOE, float NOGFHHECJBM, ref float JBPAELFIDOP, ref float LKBOHHGFJFO, int LKJHMOHMKCM)
+    {
+        if (SceneManager.GetActiveScene().name != "Match_Setup") return;
+        if (LIPNHOMGGHF.CHLJMEPFJOK == 2)
+        {
+            if (LIPNHOMGGHF.FKANHDIMMBJ[1] == __instance)
+            {
+                if (__result > OldPresetMax)
+                {
+                    __result = 10000 + (__result - OldPresetMax);
+                }
+                if (__result < OldPresetMin) __result = -10000 - (OldPresetMin - __result);
+            }
+        }
+    }
+    [HarmonyPatch(typeof(UnmappedMenu), nameof(UnmappedMenu.ODONMLDCHHF))]
+    [HarmonyPrefix]
+    private static void CustomCagePrefix(UnmappedMenu __instance, float __result, ref float CAAJBNHEFJJ, float OEGLNPMNEOE, float NOGFHHECJBM, ref float JBPAELFIDOP, ref float LKBOHHGFJFO, int LKJHMOHMKCM)
+    {
+        if (SceneManager.GetActiveScene().name != "Match_Setup") return;
+        if (LIPNHOMGGHF.CHLJMEPFJOK == 1 && LIPNHOMGGHF.ODOAPLMOJPD == 1)
+        {
+            if (LIPNHOMGGHF.FKANHDIMMBJ[9] == __instance)
+            {
+                OldCageMax = LKBOHHGFJFO;
+                OldCageMin = JBPAELFIDOP;
+                JBPAELFIDOP -= CustomMatch.CustomCagesNeg.Count;
+                LKBOHHGFJFO += CustomMatch.CustomCagesPos.Count;
+                if (CAAJBNHEFJJ >= 10000)
+                {
+                    CAAJBNHEFJJ = CAAJBNHEFJJ - 10000 + OldCageMax;
+                }
+                if (CAAJBNHEFJJ <= -10000)
+                {
+                    CAAJBNHEFJJ = CAAJBNHEFJJ + 10000 - OldCageMin;
+                }
+            }
+        }
+    }
+    [HarmonyPatch(typeof(UnmappedMenu), nameof(UnmappedMenu.ODONMLDCHHF))]
+    [HarmonyPostfix]
+    private static void CustomCagePostfix(UnmappedMenu __instance, ref float __result, float CAAJBNHEFJJ, float OEGLNPMNEOE, float NOGFHHECJBM, ref float JBPAELFIDOP, ref float LKBOHHGFJFO, int LKJHMOHMKCM)
+    {
+        if (SceneManager.GetActiveScene().name != "Match_Setup") return;
+        if (LIPNHOMGGHF.CHLJMEPFJOK == 1 && LIPNHOMGGHF.ODOAPLMOJPD == 1)
+        {
+            if (LIPNHOMGGHF.FKANHDIMMBJ[9] == __instance)
+            {
+                if (__result > OldCageMax)
+                {
+                    __result = 10000 + (__result - OldCageMax);
+                }
+                if (__result < OldCageMin) __result = -10000 - (OldCageMin - __result);
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Additional features:
 Experimental features:
 
 - Custom moves
+- Custom match types
 
 ## Getting Started
 
@@ -303,6 +304,13 @@ forwardspeedmultiplier: 1.5
   130 SetAnimationId 9 10
 140 StopAnimation
 ```
+
+## Custom Match Types
+
+Code modders can now add multiple custom match types in a non conflicting way. To do this, request WECCL to provide you a required element ID in your plugin `Start()` method. Then, WECCL will add your element to the game and it will be selectable in menus. Currently supported:  
+`WECCL.Content.CustomMatch.RegisterCustomPreset(string Name, bool PositiveValue)` will return you a match preset ID. Adding match preset to the positive end will also make them appear in career matches.  
+`WECCL.Content.CustomMatch.RegisterCustomCage(string Name, bool PositiveValue)` will return you a cage ID.  
+If you are working on something that is currently not on this list, you can request us add support for that.
 
 ## Aliases
 

--- a/README.md
+++ b/README.md
@@ -307,9 +307,10 @@ forwardspeedmultiplier: 1.5
 
 ## Custom Match Types
 
-Code modders can now add multiple custom match types in a non conflicting way. To do this, request WECCL to provide you a required element ID in your plugin `Start()` method. Then, WECCL will add your element to the game and it will be selectable in menus. Currently supported:  
-`WECCL.Content.CustomMatch.RegisterCustomPreset(string Name, bool PositiveValue)` will return you a match preset ID. Adding match preset to the positive end will also make them appear in career matches.  
-`WECCL.Content.CustomMatch.RegisterCustomCage(string Name, bool PositiveValue)` will return you a cage ID.  
+Code modders can now add multiple custom match types in a non conflicting way. To do this, request WECCL to provide you a required element ID in your plugin `Start()` method. Then, WECCL will add your element to the game and it will be selectable in menus. Currently supported:
+- `WECCL.Content.CustomMatch.RegisterCustomPreset(string Name, bool PositiveValue)` will return you a match preset ID. Adding match preset to the positive end will also make them appear in career matches.
+- `WECCL.Content.CustomMatch.RegisterCustomCage(string Name, bool PositiveValue)` will return you a cage ID.
+
 If you are working on something that is currently not on this list, you can request us add support for that.
 
 ## Aliases


### PR DESCRIPTION
Code modders can now add multiple custom match types in a non conflicting way. To do this, request WECCL to provide you a required element ID in your plugin `Start()` method. Then, WECCL will add your element to the game and it will be selectable in menus. Currently supported:  
- `WECCL.Content.CustomMatch.RegisterCustomPreset(string Name, bool PositiveValue)` will return you a match preset ID. Adding match preset to the positive end will also make them appear in career matches.  
- `WECCL.Content.CustomMatch.RegisterCustomCage(string Name, bool PositiveValue)` will return you a cage ID.  

If you are working on something that is currently not on this list, you can request us add support for that.
