### PR TITLE
Fixes 2 bugs related to Animation actions

### DIFF
--- a/Animation/AnimationActions.cs
+++ b/Animation/AnimationActions.cs
@@ -300,7 +300,9 @@ internal static class AnimationActions
             float angle = AnimationParser.ParseFloat(args["angle"]).Value.Value;
             float speed = AnimationParser.ParseFloat(args["speed"]).Value.Value;
             float inherit = AnimationParser.ParseFloat(args["inherit"]).Value.Value;
-            p.MoveTravel(angle, speed, inherit);
+            float relativeRotation = (p.a + angle) % 360;
+
+            p.MoveTravel(relativeRotation, speed, inherit);
         },  new AnimationArgument<float?>("angle", AnimationParser.ParseFloat),
             new AnimationArgument<float?>("speed", AnimationParser.ParseFloat),
             new AnimationArgument<float?>("inherit", AnimationParser.ParseFloat, "0"));

--- a/Animation/TimedAction.cs
+++ b/Animation/TimedAction.cs
@@ -42,7 +42,7 @@ internal class TimedAction : AnimationEvent
             throw new Exception($"Failed to parse animation action from line: {line}: no action specified");
         }
 
-        string command = split[1].Trim().ToLower();
+        string command = split[1].Trim(new char[] { ' ', '\uFEFF' }).ToLower();
         if (!AnimationActions.Actions.TryGetValue(command, out var action))
         {
             throw new Exception($"Unknown animation action: {command}");


### PR DESCRIPTION
Fixes a bug related to the processing of `.meta` files for animation mods. As well as another bug in which a character's rotation was not considered to perform an animation action that requires it. 

For more detailed information, see the comment below each commit: [HERE](https://github.com/davidoneseven/WECCL_davidoneseven/commit/8746096d0c994625c0d7503eb503609f22211db0#commitcomment-148253631) and [HERE](https://github.com/davidoneseven/WECCL_davidoneseven/commit/a73b5792f7458d1653e9a02122c3b1c552df95c0#commitcomment-148456380).