### PR TITLE
`SetFace` and `SetHeel` fixes + replacing `texture.png` fixes

### DIFF
--- a/API/Types/AdvFeatures.cs
+++ b/API/Types/AdvFeatures.cs
@@ -38,7 +38,7 @@ public class AdvFeatures
             return true;
         }
 
-        if (this.Command is CommandType.PlayAudio)
+        if (this.Command is CommandType.PlayAudio || this.Command is CommandType.SetFace || this.Command is CommandType.SetHeel)
         {
             expected = 1;
             return this.Args.Count == 1;

--- a/Patches/ContentPatch.cs
+++ b/Patches/ContentPatch.cs
@@ -177,18 +177,21 @@ internal class ContentPatch
                     {
                         continue;
                     }
-                    
-                    if (ResourceOverridesTextures.ContainsKey(material.mainTexture.name.ToLower()) ||
-                        ResourceOverridesTextures.ContainsKey(gameObject.name.Replace("(Clone)", "").Trim().ToLower() + "_" +
-                                                              material.mainTexture.ToString().ToLower()))
+                    string shortTexName = material.mainTexture.name.ToLower();
+                    string longTexName = gameObject.name.Replace("(Clone)", "").Trim().ToLower() + "_" +
+                                                              material.mainTexture.name.ToLower();
+
+                    if (ResourceOverridesTextures.ContainsKey(shortTexName) ||
+                        ResourceOverridesTextures.ContainsKey(longTexName))
                     {
-                        Texture2D tex = GetHighestPriorityTextureOverride(material.mainTexture.name.ToLower());
+                        string texName = (ResourceOverridesTextures.ContainsKey(shortTexName)) ? shortTexName: longTexName;
+                        Texture2D tex = GetHighestPriorityTextureOverride(texName);
                         if ((material.mainTexture.width != tex.width ||
                             material.mainTexture.height != tex.height) &&
                              !Plugin.UseFullQualityTextures.Value)
                         {
                             tex = ResizeTexture(tex, material.mainTexture.width, material.mainTexture.height);
-                            SetHighestPriorityTextureOverride(material.mainTexture.name.ToLower(), tex);
+                            SetHighestPriorityTextureOverride(texName, tex);
                         }
 
                         material.mainTexture = tex;


### PR DESCRIPTION
Fixed `SetFace` and `SetHeel` promo commands requiring 2 arguments (they should require only 1 for the wrestler id);
Fix for replacing `texture.png` object textures. Intended feature didn't work at all due to bugs.