### PR TITLE
Fixes and inprovements

### DIFF
--- a/Patches/ContentPatch.cs
+++ b/Patches/ContentPatch.cs
@@ -180,11 +180,15 @@ internal class ContentPatch
                     string shortTexName = material.mainTexture.name.ToLower();
                     string longTexName = gameObject.name.Replace("(Clone)", "").Trim().ToLower() + "_" +
                                                               material.mainTexture.name.ToLower();
+                    string longRendTexName = gameObject.name.Replace("(Clone)", "").Trim().ToLower() + "_" +
+                                            renderer.name.Trim().ToLower() + "_" +
+                                          material.mainTexture.name.ToLower();
 
                     if (ResourceOverridesTextures.ContainsKey(shortTexName) ||
-                        ResourceOverridesTextures.ContainsKey(longTexName))
+                        ResourceOverridesTextures.ContainsKey(longTexName) ||
+                        ResourceOverridesTextures.ContainsKey(longRendTexName))
                     {
-                        string texName = (ResourceOverridesTextures.ContainsKey(shortTexName)) ? shortTexName: longTexName;
+                        string texName = (ResourceOverridesTextures.ContainsKey(shortTexName)) ? shortTexName : ((ResourceOverridesTextures.ContainsKey(longTexName)) ? longTexName : longRendTexName);
                         Texture2D tex = GetHighestPriorityTextureOverride(texName);
                         if ((material.mainTexture.width != tex.width ||
                             material.mainTexture.height != tex.height) &&

--- a/Patches/ContentPatch.cs
+++ b/Patches/ContentPatch.cs
@@ -249,6 +249,28 @@ internal class ContentPatch
         }
     }
 
+    /*
+ * Patch:
+ * - Overrides the textures of the game with overrides for RawImage loaded at runtime.
+ */
+    [HarmonyPatch(typeof(RawImage), nameof(UnityEngine.UI.RawImage.OnPopulateMesh))]
+    [HarmonyPostfix]
+    public static void RawImage(ref RawImage __instance)
+    {
+
+        if (__instance.m_Texture != null && ResourceOverridesTextures.ContainsKey(__instance.m_Texture.name.ToLower()))
+        {
+            Texture2D overrideTexture = GetHighestPriorityTextureOverride(__instance.m_Texture.name.ToLower());
+            if ((__instance.m_Texture.width != overrideTexture.width || __instance.m_Texture.height != overrideTexture.height) && !Plugin.UseFullQualityTextures.Value)
+            {
+                overrideTexture = ResizeTexture(overrideTexture, __instance.m_Texture.width, __instance.m_Texture.height);
+                SetHighestPriorityTextureOverride(__instance.m_Texture.name.ToLower(), overrideTexture);
+            }
+
+            __instance.m_Texture = overrideTexture;
+        }
+    }
+
     internal static int temp = -1;
 
     /*

--- a/Patches/PromoPatch.cs
+++ b/Patches/PromoPatch.cs
@@ -393,7 +393,7 @@ internal class PromoPatch
         }
         __instance.NELODEMHJHN = 0;  //seat
         __instance.PCNHIIPBNEK[0].SetActive(false);
-        __instance.IFOCOECLBAF.SetActive(false);
+        __instance.IFOCOECLBAF?.SetActive(false);
     }
     public static void RespawnTogetherWith(UnmappedPlayer manager, UnmappedPlayer wrestler)
     {
@@ -405,7 +405,7 @@ internal class PromoPatch
         manager.EKOHAKPAOGN = wrestler.EKOHAKPAOGN;
         manager.FNNBCDPJBIO = wrestler.FNNBCDPJBIO;
         manager.PCNHIIPBNEK[0].SetActive(false);
-        manager.IFOCOECLBAF.SetActive(false);
+        manager.IFOCOECLBAF?.SetActive(false);
 
     }
 

--- a/Patches/SearchScreenPatch.cs
+++ b/Patches/SearchScreenPatch.cs
@@ -310,8 +310,8 @@ internal class SearchScreenPatch
                 MappedSound.Play(MappedSound.death[3]);
                 LogInfo("Deleting wrestler " + Characters.c[Characters.foc].name);
                 CharacterUtils.DeleteCharacter(Characters.foc);
-                Characters.foc--;
-                MappedMenus.foc--;
+                int foc = MappedMenus.foc-1 < 1 ? 1 : MappedMenus.foc - 1;
+                
                 for (int m = 1; m <= MappedPlayers.no_plays; m++)
                 {
                     if (Characters.profileChar[m] > 0)
@@ -321,6 +321,9 @@ internal class SearchScreenPatch
                 }
                 MappedSaveSystem.request = 1;
                 MappedMenus.Load();
+                MappedMenus.foc = foc;
+                Characters.foc = 0;
+
             }
         }
         // New
@@ -328,9 +331,11 @@ internal class SearchScreenPatch
         {
             MappedSound.Play(MappedSound.tanoy);
             LogInfo("Creating new wrestler");
-            CharacterUtils.CreateRandomCharacter();
+            int charID = CharacterUtils.CreateRandomCharacter();
             MappedSaveSystem.request = 1;
             MappedMenus.Load();
+            MappedMenus.foc = Array.IndexOf(MappedMenus.rank, charID);
+            Characters.foc = 0;
         }
     }
 

--- a/Utils/CharacterUtils.cs
+++ b/Utils/CharacterUtils.cs
@@ -296,7 +296,7 @@ public class CharacterUtils
         }
     }
 
-    public static void CreateRandomCharacter()
+    public static int CreateRandomCharacter()
     {
         try
         {
@@ -327,6 +327,8 @@ public class CharacterUtils
             ((MappedCharacter)Characters.c[Characters.no_chars]).Trade(9);
             ((MappedCharacter)Characters.c[Characters.no_chars]).teamName = "";
             CharacterEvents.InvokeAfterCharacterAdded(Characters.no_chars, Characters.c[Characters.no_chars]);
+            LogInfo($"New character created: {((MappedCharacter)Characters.c[Characters.no_chars]).name}");
+            return Characters.no_chars;
         }
         catch (Exception e)
         {

--- a/Utils/CharacterUtils.cs
+++ b/Utils/CharacterUtils.cs
@@ -24,6 +24,15 @@ public class CharacterUtils
         {
             SaveAsBackup(id);
 
+            if (Characters.star == id)
+            {
+                Characters.star = 1;
+            }
+            else if (Characters.star > id)
+            {
+                Characters.star--;
+            }
+
             if (Characters.wrestler == id)
             {
                 Characters.wrestler = 1;


### PR DESCRIPTION
- Renderer gameobject texture name: allows to replace some nested gameobject textures (such as microphone in conference room area)
- Auto display newly created character on the search list: if you create a new character, they will now be auto focused. If you delete a character, the displayed character next to the stats is also updated.
- Characters.star check when deleting: fix for #52 
- Null check for custom promo surprise entrant shadow
- Allows replacing RawImage textures (sea background in the booking map screen)